### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 (2025-12-19)
+
+### Features
+
+* align workflows with generic template, fix npx bootstrap installer ([5d3456c](https://github.com/templ-project/javascript/commit/5d3456ceb5182c892e5d14f2a7eed1aac44addb4))
+
 ## 1.0.1 (2025-11-23)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@templ-project/javascript-template",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A JavaScript Bootstrap/Template project using modern tools and best practices",
   "type": "module",
   "exports": {
@@ -22,7 +22,10 @@
   "bin": {
     "bootstrap": ".npx-install/bootstrap.js"
   },
-  "files": ["dist", ".npx-install"],
+  "files": [
+    "dist",
+    ".npx-install"
+  ],
   "scripts": {
     "audit-check": "npm audit --audit-level=moderate",
     "build": "run-s build:*",


### PR DESCRIPTION
# Version Update: @templ-project/javascript-template 1.1.0

## 📦 Workspace Versions

### 🏠 Root: @templ-project/javascript-template
**Version**: `1.0.1`  
**Path**: `/home/runner/work/javascript/javascript`  
**Type**: `node`  
