### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.1 (2025-12-21)
+
+### Bug Fixes
+
+* sort all config files alphabetically for consistency and maintainability ([6d77e62](https://github.com/templ-project/javascript/commit/6d77e620abc2232498b475c21ddbb1f86a629f21))
+
 ## 1.1.0 (2025-12-19)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@templ-project/javascript-template",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A JavaScript Bootstrap/Template project using modern tools and best practices",
   "author": "Templ Project",
   "license": "MIT",
@@ -43,7 +43,10 @@
       "default": "./dist/esm/index.js"
     }
   },
-  "files": [".npx-install", "dist"],
+  "files": [
+    ".npx-install",
+    "dist"
+  ],
   "homepage": "https://github.com/templ-project/javascript#readme",
   "jsdelivr": "./dist/iife/your-lib.min.js",
   "keywords": [


### PR DESCRIPTION
# Version Update: @templ-project/javascript-template 1.1.1

## 📦 Workspace Versions

### 🏠 Root: @templ-project/javascript-template
**Version**: `1.1.0`  
**Path**: `/home/runner/work/javascript/javascript`  
**Type**: `node`  
