### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/.jscpd/jscpd-badge.svg
+++ b/.jscpd/jscpd-badge.svg
@@ -1,14 +1,14 @@
 <svg width="101.6" height="20" viewBox="0 0 1016 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Copy/Paste: 0%">
   <title>Copy/Paste: 0%</title>
-  <linearGradient id="CTTNl" x2="0" y2="100%">
+  <linearGradient id="XdCDR" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="srpEm"><rect width="1016" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#srpEm)">
+  <mask id="vqZWi"><rect width="1016" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#vqZWi)">
     <rect width="726" height="200" fill="#555"/>
     <rect width="290" height="200" fill="#3C1" x="726"/>
-    <rect width="1016" height="200" fill="url(#CTTNl)"/>
+    <rect width="1016" height="200" fill="url(#XdCDR)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="626" fill="#000" opacity="0.25">Copy/Paste</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.0 (2025-12-21)
+
+### Features
+
+* sync Python/PowerShell/Shell linting tooling from generic template ([1c98c4b](https://github.com/templ-project/javascript/commit/1c98c4b42286cbbc4f2811628ad847c242a0c8eb))
+
+### Bug Fixes
+
+* sort all config files alphabetically for consistency and maintainability ([6d77e62](https://github.com/templ-project/javascript/commit/6d77e620abc2232498b475c21ddbb1f86a629f21))
+
 ## 1.1.0 (2025-12-19)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@templ-project/javascript-template",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A JavaScript Bootstrap/Template project using modern tools and best practices",
   "author": "Templ Project",
   "license": "MIT",


### PR DESCRIPTION
# Version Update: @templ-project/javascript-template 1.2.0

## 📦 Workspace Versions

### 🏠 Root: @templ-project/javascript-template
**Version**: `1.1.0`  
**Path**: `/home/runner/work/javascript/javascript`  
**Type**: `node`  
