### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 (2025-12-30)
+
+### Features
+
+* **javascript:** refactor Taskfile into modular includes structure ([f6ae784](https://github.com/templ-project/javascript/commit/f6ae78405744adec378b98d4ac17ed98dffce077))
+
 ## 1.2.0 (2025-12-21)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@templ-project/javascript-template",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A JavaScript Bootstrap/Template project using modern tools and best practices",
   "author": "Templ Project",
   "license": "MIT",
@@ -43,7 +43,10 @@
       "default": "./dist/esm/index.js"
     }
   },
-  "files": [".npx-install", "dist"],
+  "files": [
+    ".npx-install",
+    "dist"
+  ],
   "homepage": "https://github.com/templ-project/javascript#readme",
   "jsdelivr": "./dist/iife/your-lib.min.js",
   "keywords": [


### PR DESCRIPTION
# Version Update: @templ-project/javascript-template 1.3.0

## 📦 Workspace Versions

### 🏠 Root: @templ-project/javascript-template
**Version**: `1.2.0`  
**Path**: `/home/runner/work/javascript/javascript`  
**Type**: `node`  
