### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/.jscpd/jscpd-badge.svg
+++ b/.jscpd/jscpd-badge.svg
@@ -1,14 +1,14 @@
 <svg width="101.6" height="20" viewBox="0 0 1016 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Copy/Paste: 0%">
   <title>Copy/Paste: 0%</title>
-  <linearGradient id="kqpXm" x2="0" y2="100%">
+  <linearGradient id="LdktW" x2="0" y2="100%">
     <stop offset="0" stop-opacity=".1" stop-color="#EEE"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <mask id="YgwaB"><rect width="1016" height="200" rx="30" fill="#FFF"/></mask>
-  <g mask="url(#YgwaB)">
+  <mask id="cVFZQ"><rect width="1016" height="200" rx="30" fill="#FFF"/></mask>
+  <g mask="url(#cVFZQ)">
     <rect width="726" height="200" fill="#555"/>
     <rect width="290" height="200" fill="#3C1" x="726"/>
-    <rect width="1016" height="200" fill="url(#kqpXm)"/>
+    <rect width="1016" height="200" fill="url(#LdktW)"/>
   </g>
   <g aria-hidden="true" fill="#fff" text-anchor="start" font-family="Verdana,DejaVu Sans,sans-serif" font-size="110">
     <text x="60" y="148" textLength="626" fill="#000" opacity="0.25">Copy/Paste</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.0 (2025-12-30)
+
+### Features
+
+* **javascript:** refactor Taskfile into modular includes structure ([f6ae784](https://github.com/templ-project/javascript/commit/f6ae78405744adec378b98d4ac17ed98dffce077))
+
 ## 1.2.0 (2025-12-21)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@templ-project/javascript-template",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A JavaScript Bootstrap/Template project using modern tools and best practices",
   "author": "Templ Project",
   "license": "MIT",


### PR DESCRIPTION
# Version Update: @templ-project/javascript-template 1.3.0

## 📦 Workspace Versions

### 🏠 Root: @templ-project/javascript-template
**Version**: `1.2.0`  
**Path**: `/home/runner/work/javascript/javascript`  
**Type**: `node`  
